### PR TITLE
Moved all scholarships to archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,17 @@ to cover all relevant scholarships, even if they apply to specific sub groups
 (LGBTQ, specific country, etc) to enable as many students to attend GHC as
 possible!
 
-## Active Scholarships : GHC 2016
-
-| Deadline | Scholarship | Results Released |
-|----------|-------------|------------------|
-| July 10 | [Google GHC Scholarship](https://docs.google.com/forms/d/1IPr1Ju7dEt1UTzwbYn_xliDhYSmYXib4hkJ4k9KljXE/viewform) | July 27 |
-| July 17 | [Twitter @Womeng Grace Hopper Fellowship](https://twitterghcfellowship.splashthat.com/) | End of July |
-
 ## Archive (2016)
 
-| Deadline | Scholarship | Results Released |
-|----------|-------------|------------------|
-| | [Microsoft Conference Scholarships](https://careers.microsoft.com/students/scholarships) | |
-| May 13 | [GoDaddy GHC Scholarship](https://app.jobvite.com/CompanyJobs/Careers.aspx?k=Job&j=oB3X2fwn) | June 15 |
-| April 4 | [GHC Conference Scholarship](http://ghc.anitaborg.org/2016-student-academic/scholarships/) | June 1 |
-| June 15 | [Facebook GHC Scholarship](https://www.facebook.com/careers/program/gracehopper2016/) | July 15 |
-| June 17 | [Bloomberg Travel Grant](https://www.aspirations.org/2016-bloomberg-travel-grant-grace-hopper-celebration-women-computing-official-rules) | July 8 |
+| Deadline | Scholarship | Results Released | Eligibilty |
+|----------|-------------|------------------|------------|
+| | [Microsoft Conference Scholarships](https://careers.microsoft.com/students/scholarships) | | Bachelor’s degree student at a four-year college or university in the United States, Canada or Mexico |
+| May 13 | [GoDaddy GHC Scholarship](https://app.jobvite.com/CompanyJobs/Careers.aspx?k=Job&j=oB3X2fwn) | June 15 | | 
+| April 4 | [GHC Conference Scholarship](http://ghc.anitaborg.org/2016-student-academic/scholarships/) | June 1 | | 
+| June 15 | [Facebook GHC Scholarship](https://www.facebook.com/careers/program/gracehopper2016/) | July 15 | | 
+| June 17 | [Bloomberg Travel Grant](https://www.aspirations.org/2016-bloomberg-travel-grant-grace-hopper-celebration-women-computing-official-rules) | July 8 | | 
+| July 10 | [Google GHC Scholarship](https://docs.google.com/forms/d/1IPr1Ju7dEt1UTzwbYn_xliDhYSmYXib4hkJ4k9KljXE/viewform) | July 27 | |
+| July 17 | [Twitter @Womeng Grace Hopper Fellowship](https://twitterghcfellowship.splashthat.com/) | End of July | Student enrolled in a graduate program at a university in North America (USA, Canada, or Mexico) |
 
 
 

--- a/waitlistupdate
+++ b/waitlistupdate
@@ -1,5 +1,5 @@
 Please note that the companies listed are from corporate sponsors which still host a certain number of spaces/tickets for 
-students.  As it stands, regular student sign ups have a waitlist and unless you get off the waitlist, sponsorhips from 
+students.  As it stands, regular student sign ups have a waitlist and unless you get off the waitlist, sponsorships from 
 corporate sponsors are technically the only other way to guarantee space at GHC 2015.
 
 But keep trying. Don't lose hope. You are awesome.


### PR DESCRIPTION
1. Moved the Twitter and Google Travel Grant scholarships to Archive 2016.
2. Added a column "eligibility" to help overseas student not from North America. [Issue #17 ]
3. Made a minor edit in a spelling in file waitlistupdate. :) 
